### PR TITLE
Fix KeyId validation in IamJwtCredentialsProvider 

### DIFF
--- a/Yandex.Cloud.SDK/credentials/IamJwtCredentialsProvider.cs
+++ b/Yandex.Cloud.SDK/credentials/IamJwtCredentialsProvider.cs
@@ -17,6 +17,10 @@ public class IamJwtCredentialsProvider : ICredentialsProvider
     public IamJwtCredentialsProvider(RsaSecurityKey key, string serviceAccountId)
     {
         _key = key ?? throw new ArgumentNullException(nameof(key));
+        if (string.IsNullOrEmpty(_key.KeyId))
+        {
+            throw new ArgumentException("Key must have a KeyId");
+        }
         ServiceAccountId = serviceAccountId;
     }
     


### PR DESCRIPTION
This PR properly validates the KeyId from the security key and leverages the JWT framework's automatic header claim generation, addressing issues in PR #35.

## Changes

- Validates `_key.KeyId` existence during object instantiation
- Preserves the JWT security framework's automatic inclusion of the `kid` claim from the signing key

## Why this approach is better than PR #35

The Microsoft Identity Model documentation explicitly states:

> The 'alg', 'kid', 'x5t', 'enc', and 'zip' claims are added by default based on the SigningCredentials, EncryptingCredentials, and/or CompressionAlgorithm provided and SHOULD NOT be included in this dictionary as this will result in an exception being thrown.

This PR:
1. Follows best practices by letting the JWT framework automatically add the `kid` claim from the `SigningCredentials`
2. Avoids potential exceptions from duplicate claim definitions
3. Validates the key has a valid KeyId at construction time (fail-fast approach)
4. Maintains a cleaner API by using the KeyId already present in the security key
5. Preserves backward compatibility with existing code

The implementation ensures JWT tokens are correctly constructed with the proper security header claims according to Microsoft's recommendations.