### PR TITLE
Yciam 9514/oauth token deprecation

### DIFF
--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -19,7 +19,7 @@ namespace Example
     {
         public static async Task Main(string[] args)
         {
-            await WithOAuthCredentials(async credProvider =>
+            await WithIamTokenCredentials(async credProvider =>
                 {
                     var sdk = new Sdk(credProvider);
 
@@ -57,17 +57,17 @@ namespace Example
                 }
             });
         }
-        
-        private static async Task WithOAuthCredentials(Func<ICredentialsProvider, Task> action)
+
+        private static async Task WithIamTokenCredentials(Func<ICredentialsProvider, Task> action)
         {
-            var token = Environment.GetEnvironmentVariable("YC_TOKEN");
+            var token = Environment.GetEnvironmentVariable("YC_IAM_TOKEN");
             if (token == null)
             {
-                Console.WriteLine("YC_TOKEN must be set to run example");
+                Console.WriteLine("YC_IAM_TOKEN must be set to run example");
                 return;
             }
             
-            var credProvider = new OAuthCredentialsProvider(token);
+            var credProvider = new IamTokenCredentialsProvider(token);
             await action(credProvider);
         }
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ running in Yandex.Cloud) and Service Account Keys
 using Yandex.Cloud;
 using Yandex.Cloud.Credentials;
 
-var sdk = new Sdk(new IamTokenCredentialsProvider("AQAD-....."));
+var sdk = new Sdk(new IamTokenCredentialsProvider("t1.9eu..."));
 ```
 
 ### Metadata Service

--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ Installation:
 
 ## Getting started
 
-There are several options for authorization your requests - OAuth Token,
+There are several options for authorization your requests - Plain Iam Token,
 Metadata Service (if you're executing code inside VMs or Functions
 running in Yandex.Cloud) and Service Account Keys
 
-### OAuth Token
+### Plain Iam Token
 
 ```csharp
 using Yandex.Cloud;
 using Yandex.Cloud.Credentials;
 
-var sdk = new Sdk(new OAuthCredentialsProvider("AQAD-....."));
+var sdk = new Sdk(new IamTokenCredentialsProvider("AQAD-....."));
 ```
 
 ### Metadata Service

--- a/Yandex.Cloud.SDK.Tests/TestIntegration.cs
+++ b/Yandex.Cloud.SDK.Tests/TestIntegration.cs
@@ -13,13 +13,13 @@ namespace Yandex.Cloud.SDK.Tests
         [SetUp]
         public void SetUp()
         {
-            var token = Environment.GetEnvironmentVariable("YC_TOKEN");
+            var token = Environment.GetEnvironmentVariable("YC_IAM_TOKEN");
             if (token == null)
             {
-                Assert.Inconclusive("YC_TOKEN must be set to run integration tests");
+                Assert.Inconclusive("YC_IAM_TOKEN must be set to run integration tests");
             }
 
-            _sdk = new Sdk(new OAuthCredentialsProvider(token));
+            _sdk = new Sdk(new IamTokenCredentialsProvider(token));
         }
 
         [Test]

--- a/Yandex.Cloud.SDK/credentials/IamTokenCredentialsProvider.cs
+++ b/Yandex.Cloud.SDK/credentials/IamTokenCredentialsProvider.cs
@@ -1,0 +1,18 @@
+
+namespace Yandex.Cloud.Credentials
+{
+    public class IamTokenCredentialsProvider : ICredentialsProvider
+    {
+        private readonly string _iamToken;
+
+        public IamTokenCredentialsProvider(string iamToken)
+        {
+            _iamToken = iamToken;
+        }
+        
+        public string GetToken()
+        {
+            return _iamToken;
+        }
+    }
+}

--- a/Yandex.Cloud.SDK/credentials/OAuthCredentialsProvider.cs
+++ b/Yandex.Cloud.SDK/credentials/OAuthCredentialsProvider.cs
@@ -5,6 +5,7 @@ using Yandex.Cloud.Iam.V1;
 
 namespace Yandex.Cloud.Credentials
 {
+    [Obsolete("Deprecated: Please consider to use other credential provider. By the end of 2026, the use of oauth tokens in the Yandex cloud will be discontinued.")]
     public class OAuthCredentialsProvider : ICredentialsProvider
     {
         private readonly IamTokenService.IamTokenServiceClient _tokenService;


### PR DESCRIPTION
By the end of 2026, it is planned to discontinue support for OAuthToken in Yandex Cloud. In this regard, it is necessary to release a new version of the public sdk, in which mark the corresponding CredentialsProvider as deprecated.
